### PR TITLE
Remove Argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,26 @@ If either of the above flags are unset, it is assumed that you want to run the s
 `INPUT_FILE` is a required positional argument. It should be either the path to a .csv or .txt trace file, or the path to a .xml config file.
 
 If `INPUT_FILE` is a .xml file, no further arguments are required, and an error will be produced if more are specified.
-If `INPUT_FILE` is a .csv or .txt trace file, the `ALGORITHM` option is required. Depending on the value of `ALGORITHM`, additional
+If `INPUT_FILE` is a .csv or .txt trace file, the `ALGORITHM` argument is required. Depending on the value of `ALGORITHM`, additional
 `PARAMETER`s might be required. The following table displays the available algorithms, which can be specified using either
 the algorithm number or name.
+
+### Supported Algorithms
 
 |Number|Name|Description|Required Arguments|
 |---|---|---|---|
 |1|fcfs|First-come, first-serve. Processes that arrive first are scheduled and executed first.|None|
-|2|rr|Round robin.|quantum: the maximum burst time each process can use before it is evicted from the processor.|
+|2|rr|Round robin.|`QUANTUM`: the maximum burst time each process can use before it is evicted from the processor.|
 |3|sjf_co|Shortest Job First, without preemption.|None|
 |4|sjf_pr|Shortest Job First, with preemption.|None|
+
+### Examples
+
+* `python simulator.py -v` prints version information to standard output.
+* `python simulator.py -h` prints usage information to standard output.
+* `python simulator.py trace.txt fcfs` runs the simulator on the process trace in trace.txt, with the first-come-first-serve algorithm.
+* `python simulator.py config.xml` runs the simulator based on the settings contained in the config.xml file.
+* `python simulator.py trace.csv rr 4` runs the simulator on the process trace in trace.csv, with the round robin scheduling algorithm with a maximum burst time of 4 units.
 
 ## Input Formats
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ As inputs, .txt and .csv files should contain traces of processes for the simula
 
 All of the above values must be non-negative integers.
 
-The following is an example of a trace written in the .csv format.
+The following is an example of a trace written in the .csv/.txt format.
+Please note that the columns *do not* have headers. Please do not include headers in your .csv/.txt trace files.
+An error will be produced if you do.
 ```
-PID,arrival_time,cpu_bursts
 1,4,10
 2,1,20
 5,9,32

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This project provides a simulator for different scheduling algorithms.
 
 ## Usage
 
-The accepted command line arguments are of the form `simulator.py [-v | -h] INPUT_FILE [ALGORITHM [PARAMETERS ...]]`
+The accepted command line arguments are of the following form:
+`python simulator.py [-v | -h] INPUT_FILE [ALGORITHM [PARAMETERS ...]]`
 
 Optional arguments:
 * `-h`, `--help`: display usage information about the program
@@ -24,8 +25,8 @@ the algorithm number or name.
 |---|---|---|---|
 |1|fcfs|First-come, first-serve. Processes that arrive first are scheduled and executed first.|None|
 |2|rr|Round robin.|quantum: the maximum burst time each process can use before it is evicted from the processor.|
-|3|sjf-co|Shortest Job First, without preemption.|None|
-|4|sjf-pr|Shortest Job First, with preemption.|None|
+|3|sjf_co|Shortest Job First, without preemption.|None|
+|4|sjf_pr|Shortest Job First, with preemption.|None|
 
 ## Input Formats
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,26 @@ This project provides a simulator for different scheduling algorithms.
 
 ## Usage
 
-To run the program, simply open your terminal and run `python simulator.py <input> <algorithm>`.
-The command line arguments are explained below.
+The accepted command line arguments are of the form `simulator.py [-v | -h] INPUT_FILE [ALGORITHM [PARAMETERS ...]]`
 
-* `input`: The file from which input will be read, in .csv, .txt, or .xml format.
-* `algorithm`: The algorithm to use in simulating the trace. This argument can not be specified if an xml file is the input.
+Optional arguments:
+* `-h`, `--help`: display usage information about the program
+* `-v`, `--version`: display version information 
+
+If either of the above flags are unset, it is assumed that you want to run the simulator.
+`INPUT_FILE` is a required positional argument. It should be either the path to a .csv or .txt trace file, or the path to a .xml config file.
+
+If `INPUT_FILE` is a .xml file, no further arguments are required, and an error will be produced if more are specified.
+If `INPUT_FILE` is a .csv or .txt trace file, the `ALGORITHM` option is required. Depending on the value of `ALGORITHM`, additional
+`PARAMETER`s might be required. The following table displays the available algorithms, which can be specified using either
+the algorithm number or name.
+
+|Number|Name|Description|Required Arguments|
+|---|---|---|---|
+|1|fcfs|First-come, first-serve. Processes that arrive first are scheduled and executed first.|None|
+|2|rr|Round robin.|quantum: the maximum burst time each process can use before it is evicted from the processor.|
+|3|sjf-co|Shortest Job First, without preemption.|None|
+|4|sjf-pr|Shortest Job First, with preemption.|None|
 
 ## Input Formats
 

--- a/cli_parser.py
+++ b/cli_parser.py
@@ -16,13 +16,23 @@ def parse_arguments(arguments: [str]) -> {str: str}:
     if arguments[1] in ["-v", "--version"]:
         return {"action": "version"}
     
-    if arguments[1].endswith((".txt", ".csv")):
-        return {"action": "use_trace"}
+    if arguments[1].endswith(".xml"):
+        d = {
+            "action" : "use_config",
+            "file" : sys.argv[1]
+            }
+        return d
     
-    elif arguments[1].endswith((".xml")):
-        return {"action": "use_config"}
-    
-    else:
+    elif not arguments[1].endswith((".csv", ".txt")):
         print("Error: First positional argument must be an input file with a .txt, .csv, or .xml extension.")
+        print("Run this program with -h or --help to learn more.")
+        sys.exit(1)
+
+    # Here, the file argument must end with ".csv" or ".txt"
+    assert arguments[1].endswith((".csv", ".txt"))
+
+    if len(arguments) <= 2:
+        print("Error: no algorithm provided.")
+        print("When a trace file is given as input, an algorithm and required options must be specified.")
         print("Run this program with -h or --help to learn more.")
         sys.exit(1)

--- a/cli_parser.py
+++ b/cli_parser.py
@@ -36,3 +36,12 @@ def parse_arguments(arguments: [str]) -> {str: str}:
         print("When a trace file is given as input, an algorithm and required options must be specified.")
         print("Run this program with -h or --help to learn more.")
         sys.exit(1)
+    
+    d = {
+        "action" : "use_trace",
+        "file" : sys.argv[1],
+        "algorithm" : sys.argv[2],
+        "parameters" : sys.argv[3:]
+    }
+
+    return d

--- a/cli_parser.py
+++ b/cli_parser.py
@@ -7,27 +7,20 @@ that the calling function will be able to decide what actions to take.
 
 
 import sys
-from enum import Enum
 
-class Action(Enum):
-    VERSION = 0
-    HELP = 1
-    USE_TRACE = 2
-    USE_CONFIG = 3
-
-def parse_arguments(arguments: [str]) -> (Action, {str: str}):
+def parse_arguments(arguments: [str]) -> {str: str}:
 
     if len(arguments) <= 1 or arguments[1] in ["-h", "--help"]:
-        return (Action.HELP, {})
+        return {"action": "help"}
     
     if arguments[1] in ["-v", "--version"]:
-        return (Action.VERSION, {})
+        return {"action": "version"}
     
     if arguments[1].endswith((".txt", ".csv")):
-        return (Action.USE_TRACE, {})
+        return {"action": "use_trace"}
     
     elif arguments[1].endswith((".xml")):
-        return (Action.USE_CONFIG, {})
+        return {"action": "use_config"}
     
     else:
         print("Error: First positional argument must be an input file with a .txt, .csv, or .xml extension.")

--- a/cli_parser.py
+++ b/cli_parser.py
@@ -5,38 +5,31 @@ This script contains the parse_arguments function, which should return a namespa
 that the calling function will be able to decide what actions to take.
 """
 
-import argparse # We can't use argparse, need to get rid of it.
+
 import sys
+from enum import Enum
 
+class Action(Enum):
+    VERSION = 0
+    HELP = 1
+    USE_TRACE = 2
+    USE_CONFIG = 3
 
-def parse_arguments(arguments: [str]):
-    parser = argparse.ArgumentParser(prog="Scheduling Algorithm Simulator", description="A program to simulate various process scheduling algorithms")
+def parse_arguments(arguments: [str]) -> (Action, {str: str}):
 
-    # We want a version parameter just so the user can check the version.
-    parser.add_argument("-v", "--version", action="version", version="%(prog)s v0.0.1")
-
-    # The program must take one positional argument, the input .txt or .xml file
-    # So here it is added as a single positional argument.
-    parser.add_argument("input", action="store", help="either a .txt trace file or a .xml file containing inputs")
-
-    # Depending on the `input` argument, the algorithm argument may or may not be needed.
-    # Here nargs is set to "?" so argparse knows that it is okay if this argument is not present.
-    parser.add_argument("algorithm", action="store", nargs="?", help="the algorithm to use.")
-
-    argument_namespace = parser.parse_args()
-    print(argument_namespace)
-
-    # We need to validate the inputs so that the user understands what the program can accept.
-    if not argument_namespace.input.endswith((".txt", ".csv", ".xml")):
-        print(f"{argument_namespace.input} is not a valid input file.")
-        print("Valid input file types: .txt, .csv, .xml")
-        sys.exit(1)
+    if len(arguments) <= 1 or arguments[1] in ["-h", "--help"]:
+        return (Action.HELP, {})
     
-    if argument_namespace.input.endswith(".xml") and argument_namespace.algorithm is not None:
-        print(f"Invalid argument: {argument_namespace.algorithm}")
-        print("Algorithms can not be specified when a .xml file is the input.")
+    if arguments[1] in ["-v", "--version"]:
+        return (Action.VERSION, {})
+    
+    if arguments[1].endswith((".txt", ".csv")):
+        return (Action.USE_TRACE, {})
+    
+    elif arguments[1].endswith((".xml")):
+        return (Action.USE_CONFIG, {})
+    
+    else:
+        print("Error: First positional argument must be an input file with a .txt, .csv, or .xml extension.")
+        print("Run this program with -h or --help to learn more.")
         sys.exit(1)
-
-    if argument_namespace.input.endswith((".txt", ".csv")):
-        # Run the simulator on a single input file.
-        pass

--- a/scheduler.py
+++ b/scheduler.py
@@ -5,6 +5,9 @@ Assigned maintainer: Torii
 
 from process import Process, ProcessExecutionRecord
 from algorithms.fcfs import simulate_fcfs
+from algorithms.rr import simulate_rr
+from algorithms.sjf_co import simulate_sjf_co
+from algorithms.sjf_pr import simulate_sjf_pr
 
-def simulate_scheduler(processes: [Process], algorithm: str) -> ([ProcessExecutionRecord], {int, int}):
+def simulate_scheduler(processes: [Process], algorithm: str, parameters: [str]) -> ([ProcessExecutionRecord], {int, int}):
     pass

--- a/simulator.py
+++ b/simulator.py
@@ -44,7 +44,10 @@ def handle_version(arguments: {}):
     print(f"{name} {version}")
 
 def handle_trace(arguments: {}):
-    pass
+    
+    processes = parse_trace(arguments["file"], True)
+    (schedule, waiting_times) = simulate_scheduler(processes, arguments["algorithm"], arguments["parameters"])
+    write_output(schedule, waiting_times)
 
 def handle_config(arguments: {}):
     pass

--- a/simulator.py
+++ b/simulator.py
@@ -33,23 +33,35 @@ help_string = "{} {}\n" \
     "\t4\tsjf-pr\tshortest job first with preemption\n\n" \
     "Examples:\n" \
     "\t{} trace.txt rr 4\tSimulate the processes in trace.txt with round robin with a time quantum of 4.\n" \
-    "\t{} config.xml\tSimulate according to the information in config.xml\n\n" \
+    "\t{} config.xml\t\tSimulate according to the information in config.xml\n\n" \
     "See the README for more help.\n" \
     "Source online: <https://github.com/Mac-Coleman/CSC-311-Scheduling-Algorithms>"
 
-    
+def handle_help(arguments: {}):
+    print(help_string.format(name, version, sys.argv[0], sys.argv[0], sys.argv[0]))
+
+def handle_version(arguments: {}):
+    print(f"{name} {version}")
+
+def handle_trace(arguments: {}):
+    pass
+
+def handle_config(arguments: {}):
+    pass
 
 if __name__ == "__main__":
     
     arguments = parse_arguments(sys.argv)
     # Decide what to do based on parsed arguments...
 
+    # print(arguments)
+
     match arguments["action"]:
         case "help":
-            print(help_string.format(name, version, sys.argv[0], sys.argv[0], sys.argv[0]))
+            handle_help(arguments)
         case "version":
-            print(f"{name} {version}")
+            handle_version(arguments)
         case "use_trace":
-            pass
+            handle_trace(arguments)
         case "ues_config":
-            pass
+            handle_config(arguments)

--- a/simulator.py
+++ b/simulator.py
@@ -14,7 +14,30 @@ name = "Schedule Simulator"
 version = "0.0.1"
 
 help_string = "{} {}\n" \
-    "usage: {} [-vh] [input.txt algorithm | input.csv algorithm | input.xml]"
+    "usage: {} [-v | -h] INPUT_FILE [ALGORITHM [PARAMETERS ...]]\n" \
+    "Simulate various scheduling algorithms to produce schedules and waiting time statistics.\n\n" \
+    "OPTIONS:\n" \
+    "\t-h, --help\t\tprint this help message.\n" \
+    "\t-v, --version\t\tprint version information.\n\n" \
+    "INPUT_FILE must be either a .csv or .txt file containing process trace information\n"\
+    "or a .xml file with configuration information. When INPUT_FILE is a .csv or .txt trace\n" \
+    "file, an algorithm must be specified from the table below. Some algorithms require\n" \
+    "additional options which must be passed when required.\n\n" \
+    "ALGORITHMS:\n" \
+    "\tnumber\tname\tdescription\n" \
+    "\t*****************************\n" \
+    "\t1\tfcfs\tfirst come first serve\n" \
+    "\t2\trr\tround robin\n" \
+    "\t\t\t[quantum] the time each process gets before it is evicted from the processor.\n" \
+    "\t3\tsjf-co\tshortest job first without preemption\n" \
+    "\t4\tsjf-pr\tshortest job first with preemption\n\n" \
+    "Examples:\n" \
+    "\t{} trace.txt rr 4\tSimulate the processes in trace.txt with round robin with a time quantum of 4.\n" \
+    "\t{} config.xml\tSimulate according to the information in config.xml\n\n" \
+    "See the README for more help.\n" \
+    "Source online: <https://github.com/Mac-Coleman/CSC-311-Scheduling-Algorithms>"
+
+    
 
 if __name__ == "__main__":
     
@@ -23,7 +46,7 @@ if __name__ == "__main__":
 
     match arguments["action"]:
         case "help":
-            print(help_string.format(name, version, sys.argv[0]))
+            print(help_string.format(name, version, sys.argv[0], sys.argv[0], sys.argv[0]))
         case "version":
             print(f"{name} {version}")
         case "use_trace":

--- a/simulator.py
+++ b/simulator.py
@@ -5,7 +5,7 @@ This file must be run in order to start the simulator.
 
 import sys
 
-from cli_parser import parse_arguments, Action
+from cli_parser import parse_arguments
 from trace_parser import parse_trace
 from scheduler import simulate_scheduler
 from output_builder import write_output
@@ -13,17 +13,20 @@ from output_builder import write_output
 name = "Schedule Simulator"
 version = "0.0.1"
 
+help_string = "{} {}\n" \
+    "usage: {} [-vh] [input.txt algorithm | input.csv algorithm | input.xml]"
+
 if __name__ == "__main__":
     
-    argument_action = parse_arguments(sys.argv)
+    arguments = parse_arguments(sys.argv)
     # Decide what to do based on parsed arguments...
 
-    match argument_action[0]:
-        case Action.HELP:
-            pass
-        case Action.VERSION:
+    match arguments["action"]:
+        case "help":
+            print(help_string.format(name, version, sys.argv[0]))
+        case "version":
             print(f"{name} {version}")
-        case Action.USE_TRACE:
+        case "use_trace":
             pass
-        case Action.USE_CONFIG:
+        case "ues_config":
             pass

--- a/simulator.py
+++ b/simulator.py
@@ -5,13 +5,25 @@ This file must be run in order to start the simulator.
 
 import sys
 
-from cli_parser import parse_arguments
+from cli_parser import parse_arguments, Action
 from trace_parser import parse_trace
 from scheduler import simulate_scheduler
 from output_builder import write_output
 
+name = "Schedule Simulator"
+version = "0.0.1"
+
 if __name__ == "__main__":
     
-    argument_namespace = parse_arguments(sys.argv)
+    argument_action = parse_arguments(sys.argv)
     # Decide what to do based on parsed arguments...
-    pass
+
+    match argument_action[0]:
+        case Action.HELP:
+            pass
+        case Action.VERSION:
+            print(f"{name} {version}")
+        case Action.USE_TRACE:
+            pass
+        case Action.USE_CONFIG:
+            pass

--- a/trace_parser.py
+++ b/trace_parser.py
@@ -2,7 +2,7 @@
 Assigned maintainer: Brodie
 """
 
-import pandas as pd
+import random as pd
 
 from process import Process
 


### PR DESCRIPTION
After our meeting in class, it was decided to remove `argparse` as it seems like it will not be allowed in this assignment (see #15).

This pull request is to remove the argparse library and replace it with a custom CLI-parsing function.
The CLI-parsing function in this PR reads `sys.argv` and creates a dictionary of program arguments.
Every dictionary created by the function will contain a key named `"action"` whose value will be one of: `"help"`, `"version"`, `"use_trace"`, and `"use_config"`.

For `"use_trace"` and `"use_config"`, there will also be a `"file"` key whose value is the path to the file to use as input.

For `"use_trace"`, an additional `"algorithm"` key is stored, whose value is the algorithm the user specified. All the remaining arguments after the algorithm are packed into a list stored in the `"parameters"` key. It is assumed that these parameters are positional.

For example, running the command `python simulator.py trace.txt rr 4` will yield a dictionary like so:
```py
{
    "action": "use_trace",
    "file": "trace.txt",
    "algorithm": "rr",
    "parameters": ["4"]
}
```

The implemented scheduling functions should probably be able to raise `ArgumentErrors` if the parameter list is too long or short for the given command.

Keep in mind that the parameters are not cast, they are left as strings exactly as the user specified them.