### PR TITLE
Typehinting fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 __pycache__
 *.pyc
 
+# We also don't need to be committing editor settings.
+.vscode
+
+# Or mypy's cache.
+.mypy_cache
+
 # Also, we don't want binary files (at least, not without GitLFS
 *.pdf
 *.docx

--- a/README.md
+++ b/README.md
@@ -42,24 +42,53 @@ the algorithm number or name.
 
 ### Text / Comma-Separated Value (.txt, .csv)
 
-As inputs, .txt and .csv files should contain traces of processes for the simulator to run. At a minimum, the required columns are:
+As inputs, .txt and .csv files should contain traces of processes for the simulator to run.
+All .csv and .txt files *must* contain these four columns, in exactly this order, from left to right:
+
 * PID: Process ID
 * arrival_time: The time at which the process arrives to be scheduled.
 * cpu_bursts: The remaining length of the process until it is terminated.
+* priority: The priority of the process. This is *required*, even if you do not intend to use an algorithm that requires priority. It will simply be ignored.
 
-All of the above values must be non-negative integers.
+All of the values in each column *must* be non-negative integers.
+Processes with lower numbers in the priority column are considered higher priority than those with a high number in the priority column.
 
 The following is an example of a trace written in the .csv/.txt format.
 Please note that the columns *do not* have headers. Please do not include headers in your .csv/.txt trace files.
 An error will be produced if you do.
 ```
-1,4,10
-2,1,20
-5,9,32
-7,9,19
-8,3,15
+1,4,10,4
+2,1,20,4
+5,9,32,5
+7,9,19,9
+8,3,15,2
 ```
 
 ### Extensible Markup Language (.xml)
 
 The function of .xml files as input is not yet decided.
+
+## Output files
+
+The program will produce two output files, `schedule.txt`, and `wait_times.txt`.
+`schedule.txt` is a comma-separated-value file in which each line represents a process that was executed on the CPU.
+The lines of `schedule.txt` are arranged in order, so the first process to have been run will be the first process line, the second line will be the second process to run, and so on.
+
+### schedule.txt
+
+The exact columns of `schedule.txt` are as follows:
+
+* PID: The process ID of the process that was executed.
+* Start time: The time at which the process began executing.
+* Burst length: The number of CPU bursts that the process executed before it left the processor.
+* Time remaining: The number of CPU bursts that had yet to be completed by the time the process left the processor.
+
+### wait_times.txt
+
+`wait_times.txt` is a comma-separated-value file in which each line represents a process that was executed on the CPU.
+This file will only contain one line for each process in the trace file, with two columns in each line.
+
+The columns of `wait_times.txt` are as follows:
+
+* PID: The process ID of the process that was executed.
+* Wait time: The amount of CPU time units that the process spent waiting in the ready queue, not being executed, before it was completed.

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ The function of .xml files as input is not yet decided.
 ## Output files
 
 The program will produce two output files, `schedule.txt`, and `wait_times.txt`.
-`schedule.txt` is a comma-separated-value file in which each line represents a process that was executed on the CPU.
-The lines of `schedule.txt` are arranged in order, so the first process to have been run will be the first process line, the second line will be the second process to run, and so on.
 
 ### schedule.txt
+
+`schedule.txt` is a comma-separated-value file in which each line represents a process that was executed on the CPU.
+The lines of `schedule.txt` are arranged in order, so the first process to have been run will be the first process line, the second line will be the second process to run, and so on.
 
 The exact columns of `schedule.txt` are as follows:
 

--- a/algorithms/fcfs.py
+++ b/algorithms/fcfs.py
@@ -5,7 +5,7 @@ Assigned maintainer: Mac
 from process import Process, ProcessExecutionRecord
 from trace_parser import parse_trace
 
-def simulate_fcfs(arriving_processes: list[Process], args: list) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
+def simulate_fcfs(arriving_processes: list[Process], args: list[str]) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     
     cpu_time: int = arriving_processes[0].arrival_time
     execution_schedule: list[ProcessExecutionRecord] = []

--- a/algorithms/fcfs.py
+++ b/algorithms/fcfs.py
@@ -5,11 +5,11 @@ Assigned maintainer: Mac
 from process import Process, ProcessExecutionRecord
 from trace_parser import parse_trace
 
-def simulate_fcfs(arriving_processes: [Process], args: list) -> [ProcessExecutionRecord]:
+def simulate_fcfs(arriving_processes: list[Process], args: list) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     
     cpu_time: int = arriving_processes[0].arrival_time
-    execution_schedule: [ProcessExecutionRecord] = []
-    waiting_times: {int: int} = {}
+    execution_schedule: list[ProcessExecutionRecord] = []
+    waiting_times: dict[int, int] = {}
 
     for arriving_process in arriving_processes:
 

--- a/algorithms/rr.py
+++ b/algorithms/rr.py
@@ -4,5 +4,5 @@ Assigned maintainer: Mac
 
 from process import Process, ProcessExecutionRecord
 
-def simulate_rr(arriving_processes: list[Process], args: list) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
+def simulate_rr(arriving_processes: list[Process], args: list[str]) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     pass

--- a/algorithms/rr.py
+++ b/algorithms/rr.py
@@ -4,5 +4,5 @@ Assigned maintainer: Mac
 
 from process import Process, ProcessExecutionRecord
 
-def simulate_rr(arriving_processes: [Process], time_quantum: int) -> ([ProcessExecutionRecord], {int : int}):
+def simulate_rr(arriving_processes: list[Process], args: list) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     pass

--- a/algorithms/sjf_co.py
+++ b/algorithms/sjf_co.py
@@ -4,5 +4,5 @@ Assigned maintainer: Torii
 
 from process import Process, ProcessExecutionRecord
 
-def simulate_sjf_co(arriving_processes: list[Process], args: list) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
+def simulate_sjf_co(arriving_processes: list[Process], args: list[str]) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     pass

--- a/algorithms/sjf_co.py
+++ b/algorithms/sjf_co.py
@@ -4,5 +4,5 @@ Assigned maintainer: Torii
 
 from process import Process, ProcessExecutionRecord
 
-def simulate_sjf_co(arriving_processes: [Process]) -> ([ProcessExecutionRecord], {int : int}):
+def simulate_sjf_co(arriving_processes: list[Process], args: list) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     pass

--- a/algorithms/sjf_pr.py
+++ b/algorithms/sjf_pr.py
@@ -4,5 +4,5 @@ Assigned maintainer: Torii
 
 from process import Process, ProcessExecutionRecord
 
-def simulate_sjf_pr(arriving_processes: [Process]) -> ([ProcessExecutionRecord], {int : int}):
+def simulate_sjf_pr(arriving_processes: list[Process], args: list) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     pass

--- a/algorithms/sjf_pr.py
+++ b/algorithms/sjf_pr.py
@@ -4,5 +4,5 @@ Assigned maintainer: Torii
 
 from process import Process, ProcessExecutionRecord
 
-def simulate_sjf_pr(arriving_processes: list[Process], args: list) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
+def simulate_sjf_pr(arriving_processes: list[Process], args: list[str]) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     pass

--- a/cli_parser.py
+++ b/cli_parser.py
@@ -8,7 +8,7 @@ that the calling function will be able to decide what actions to take.
 
 import sys
 
-def parse_arguments(arguments: [str]) -> {str: str}:
+def parse_arguments(arguments: list[str]) -> dict[str, str | list[str]]:
 
     if len(arguments) <= 1 or arguments[1] in ["-h", "--help"]:
         return {"action": "help"}
@@ -17,11 +17,11 @@ def parse_arguments(arguments: [str]) -> {str: str}:
         return {"action": "version"}
     
     if arguments[1].endswith(".xml"):
-        d = {
+        c: dict[str, str | list[str]] = {
             "action" : "use_config",
             "file" : sys.argv[1]
             }
-        return d
+        return c
     
     elif not arguments[1].endswith((".csv", ".txt")):
         print("Error: First positional argument must be an input file with a .txt, .csv, or .xml extension.")
@@ -37,7 +37,7 @@ def parse_arguments(arguments: [str]) -> {str: str}:
         print("Run this program with -h or --help to learn more.")
         sys.exit(1)
     
-    d = {
+    d: dict[str, str | list[str]] = {
         "action" : "use_trace",
         "file" : sys.argv[1],
         "algorithm" : sys.argv[2],

--- a/output_builder.py
+++ b/output_builder.py
@@ -4,7 +4,7 @@ Assigned maintainer: Brodie
 
 from process import ProcessExecutionRecord
 
-def write_output(records: [ProcessExecutionRecord], waiting_times: {int : int}) -> None:
+def write_output(records: list[ProcessExecutionRecord], waiting_times: dict[int, int]) -> None:
     # creates the schedule file
     # writes the execution record information
     schedule_file = open("schedule.txt", 'w')
@@ -27,7 +27,7 @@ if __name__ == "__main__":
 
     test_records = []
     for i in range(10):
-        test_records.append(ProcessExecutionRecord(i, i*3, i*2, i))
+        test_records.append(ProcessExecutionRecord(i, i*3, i*2, i, None))
 
     write_output(test_records, wait_times)
     

--- a/output_builder.py
+++ b/output_builder.py
@@ -19,7 +19,7 @@ def write_output(records: list[ProcessExecutionRecord], waiting_times: dict[int,
         wait_times_file.write(f"{pid},{waiting_times[pid]}\n")
     wait_times_file.close()
 
-def print_output_data(records, waiting_times):
+def print_output_data(records: list[ProcessExecutionRecord], waiting_times: dict[int, int]) -> None:
     pass
 
 if __name__ == "__main__":

--- a/process.py
+++ b/process.py
@@ -23,7 +23,7 @@ class Process:
         """
         return ProcessExecutionRecord(self.pid, execution_start_time, execution_burst_time, self.burst_time, self.priority)
     
-    def execute(self, time: int):
+    def execute(self, time: int) -> None:
         """
         Decrements the remaining burst time of the process by [time] units.
         Used to simulate execution of a process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.mypy]
+strict = true

--- a/scheduler.py
+++ b/scheduler.py
@@ -12,7 +12,7 @@ from algorithms.rr import simulate_rr
 from algorithms.sjf_co import simulate_sjf_co
 from algorithms.sjf_pr import simulate_sjf_pr
 
-def simulate_scheduler(processes: [Process], algorithm: str, parameters: [str]) -> ([ProcessExecutionRecord], {int, int}):
+def simulate_scheduler(processes: list[Process], algorithm: str, parameters: list[str]) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
     algoDict={ # dictionary with possible algorithm inputs as keys, and pointers to the correct algorithm function as values
         "fcfs":simulate_fcfs,
         "rr":simulate_rr,        

--- a/scheduler.py
+++ b/scheduler.py
@@ -12,8 +12,10 @@ from algorithms.rr import simulate_rr
 from algorithms.sjf_co import simulate_sjf_co
 from algorithms.sjf_pr import simulate_sjf_pr
 
+from typing import Callable
+
 def simulate_scheduler(processes: list[Process], algorithm: str, parameters: list[str]) -> tuple[list[ProcessExecutionRecord], dict[int, int]]:
-    algoDict={ # dictionary with possible algorithm inputs as keys, and pointers to the correct algorithm function as values
+    algoDict: dict[str, Callable[[list[Process], list[str]], tuple[list[ProcessExecutionRecord], dict[int, int]]]] = { # dictionary with possible algorithm inputs as keys, and pointers to the correct algorithm function as values
         "fcfs":simulate_fcfs,
         "rr":simulate_rr,        
         "sjf_co":simulate_sjf_co,

--- a/simulator.py
+++ b/simulator.py
@@ -38,15 +38,15 @@ help_string = "{} {}\n" \
     "See the README for more help.\n" \
     "Source online: <https://github.com/Mac-Coleman/CSC-311-Scheduling-Algorithms>"
 
-def handle_help(arguments: dict[str, str | list[str]]):
+def handle_help(arguments: dict[str, str | list[str]]) -> None:
     print(help_string.format(name, version, sys.argv[0], sys.argv[0], sys.argv[0]))
 
-def handle_version(arguments: dict[str, str | list[str]]):
+def handle_version(arguments: dict[str, str | list[str]]) -> None:
     print(f"{name} {version}")
 
-def handle_trace(arguments: dict[str, str | list[str]]):
+def handle_trace(arguments: dict[str, str | list[str]]) -> None:
     
-    processes = parse_trace(arguments["file"], True)
+    processes = parse_trace(cast(str, arguments["file"]), True)
     (schedule, waiting_times) = simulate_scheduler(processes, cast(str, arguments["algorithm"]), cast(list[str], arguments["parameters"]))
     write_output(schedule, waiting_times)
 
@@ -62,7 +62,7 @@ def handle_trace(arguments: dict[str, str | list[str]]):
     for (key, value) in waiting_times.items():
         print(f"pid: {key}, time: {value}")
 
-def handle_config(arguments: dict[str, str | list[str]]):
+def handle_config(arguments: dict[str, str | list[str]]) -> None:
     pass
 
 if __name__ == "__main__":

--- a/simulator.py
+++ b/simulator.py
@@ -4,6 +4,7 @@ This file must be run in order to start the simulator.
 """
 
 import sys
+from typing import cast
 
 from cli_parser import parse_arguments
 from trace_parser import parse_trace
@@ -37,16 +38,16 @@ help_string = "{} {}\n" \
     "See the README for more help.\n" \
     "Source online: <https://github.com/Mac-Coleman/CSC-311-Scheduling-Algorithms>"
 
-def handle_help(arguments: {}):
+def handle_help(arguments: dict[str, str | list[str]]):
     print(help_string.format(name, version, sys.argv[0], sys.argv[0], sys.argv[0]))
 
-def handle_version(arguments: {}):
+def handle_version(arguments: dict[str, str | list[str]]):
     print(f"{name} {version}")
 
-def handle_trace(arguments: {}):
+def handle_trace(arguments: dict[str, str | list[str]]):
     
     processes = parse_trace(arguments["file"], True)
-    (schedule, waiting_times) = simulate_scheduler(processes, arguments["algorithm"], arguments["parameters"])
+    (schedule, waiting_times) = simulate_scheduler(processes, cast(str, arguments["algorithm"]), cast(list[str], arguments["parameters"]))
     write_output(schedule, waiting_times)
 
     print("Arriving processes:")
@@ -61,7 +62,7 @@ def handle_trace(arguments: {}):
     for (key, value) in waiting_times.items():
         print(f"pid: {key}, time: {value}")
 
-def handle_config(arguments: {}):
+def handle_config(arguments: dict[str, str | list[str]]):
     pass
 
 if __name__ == "__main__":

--- a/trace_parser.py
+++ b/trace_parser.py
@@ -7,7 +7,7 @@ import math
 
 # parses the trace file and returns a list of process objects
 # output is a list of process objects that are sorted by arrival time
-def parse_trace(file_name, arrival_time_cutoff=math.inf):
+def parse_trace(file_name: str, arrival_time_cutoff: int | float = math.inf) -> list[Process]:
     '''
     file_name: exact file name
     arrival_time_cutoff:
@@ -22,11 +22,11 @@ def parse_trace(file_name, arrival_time_cutoff=math.inf):
     for line in process_lines:
         # variables are specified for readability
         # split at commas due to csv file format
-        line = line.split(',')
-        process_list.append(Process(pid=int(line[0]), 
-                                 arrival_time=int(line[1]),
-                                 burst_time=int(line[2]),
-                                 priority=int(line[3])))
+        cells = line.split(',')
+        process_list.append(Process(pid=int(cells[0]), 
+                                 arrival_time=int(cells[1]),
+                                 burst_time=int(cells[2]),
+                                 priority=int(cells[3])))
     trace.close()
 
     # starts the sorting and organizing of the process list
@@ -48,7 +48,7 @@ def parse_trace(file_name, arrival_time_cutoff=math.inf):
 
 
 
-def quick_sort(processes, low, high):
+def quick_sort(processes: list[Process], low: int, high: int) -> list[Process]:
     if low < high:
         pivot = processes[high].arrival_time
         i = low-1


### PR DESCRIPTION
This pull request is to fix broken typehints in the project, as well as add configuration files for mypy. Mypy can now be used to statically check the type safety of the project. As laid out in `pyproject.toml`, mypy is set to strict mode, so every function must have type hints. Previously I was not aware that python type hints were basically just comments without a linter like mypy.

The .gitignore has also been updated to ignore the .mypy_cache directory.